### PR TITLE
Fix loading WASM with `@sqlite.org/sqlite-wasm`

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,7 +1,13 @@
 import { Options } from "@wdio/types";
 
 export const config: Options.Testrunner = {
-  runner: "browser",
+  runner: ["browser", {
+    viteConfig: {
+      optimizeDeps: {
+        exclude: ["@sqlite.org/sqlite-wasm"],
+      }
+    }
+  }],
   reporters: ["spec"],
   capabilities: [
     {


### PR DESCRIPTION
Hey @piotrblasiak 👋 

The reason WASM couldn't be loaded was because the URL to the WASM file wasn't correctly determined. Since WebdriverIO uses Vite as dev server it would get pre-compiled and optimized causing the code location to change. In order to avoid that and fix the problem you can exclude the dependency from being optimized.

Hope that helps!

Cheers
Christian